### PR TITLE
fix(portal): show the plate picker only in Plate mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Portal app shows a neutral note when an order contains both plate-resident and standalone (vial) samples.
+
+### Fixed
+- Portal app: the plate-subset picker is now shown only in Plate mode (in Vial mode it had no effect on the queue).
+
 ## [0.9.3] - 2026-07-14
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qg"
-version = "0.9.3"
+version = "0.9.4"
 description = "Queue generation system for mass spectrometry instruments. Generates sample queues with QC injections for XCalibur, Chronos, and Hystar, with B-Fabric LIMS integration for sample loading and workunit upload."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/qg/apps/queue_app.py
+++ b/src/qg/apps/queue_app.py
@@ -743,9 +743,22 @@ def _(full_samples_df, is_employee, selected_orders):
 
 
 @app.cell
-def _(all_plates, plates_select, selected_orders):
+def _(container_has_plates, container_has_vials):
+    # Neutral heads-up when the order mixes plate-resident and standalone samples.
+    _mixed_note = shared.make_mixed_order_note(
+        has_plates=bool(container_has_plates), has_vials=bool(container_has_vials)
+    )
+    _mixed_note if _mixed_note is not None else mo.md("")
+    return
+
+
+@app.cell
+def _(all_plates, plates_select, queue_type_field, selected_orders):
+    # Plate subsetting only affects the Plate load path; in Vial mode get_samples ignores
+    # plate_ids (bfabric_utils.py), so showing the picker there is an inert, misleading control.
     _has_plates = any(all_plates.get(o[0]) for o in selected_orders) if selected_orders else False
-    plates_select if _has_plates else mo.md("")
+    _show_picker = _has_plates and queue_type_field.value == "Plate"
+    plates_select if _show_picker else mo.md("")
     return
 
 

--- a/src/qg/apps/queue_app_shared.py
+++ b/src/qg/apps/queue_app_shared.py
@@ -832,6 +832,20 @@ def make_queue_type_field(
     return mo.ui.dropdown(options=options, value=default, label="Queue Type"), warning
 
 
+def make_mixed_order_note(*, has_plates: bool, has_vials: bool) -> mo.Html | None:
+    """Neutral note when an order holds both plate-resident and standalone (vial) samples.
+
+    Purely informational — it states the composition, not its consequences (queue-type
+    guidance is intentionally left to a later change). Returns ``None`` unless both are present.
+    """
+    if has_plates and has_vials:
+        return mo.callout(
+            mo.md("This order contains both plate-resident and standalone (vial) samples."),
+            kind="info",
+        )
+    return None
+
+
 def make_start_position_field(
     config: QGConfiguration, *, queue_type: str | None, plate_layout: str | None
 ) -> mo.ui.dropdown | None:

--- a/tests/gui/_helpers.py
+++ b/tests/gui/_helpers.py
@@ -213,3 +213,34 @@ def assert_warn(page: Page, text: str) -> None:
 def assert_danger(page: Page, text: str) -> None:
     """Assert a red danger callout containing ``text`` is visible."""
     _assert_callout(page, "danger", text)
+
+
+# ----------------------------------------------------------------------------
+# Plate picker + mixed-order note (portal main-area widgets)
+# ----------------------------------------------------------------------------
+
+# The plate-subset picker is the only `mo.ui.multiselect` in the app (queue_app.py:585),
+# and it renders in the main area (not the sidebar), so a plain element count is an
+# unambiguous shown/hidden probe — its display cell renders `mo.md("")` when hidden.
+_MIXED_NOTE_TEXT = "both plate-resident and standalone"
+
+
+def expect_plate_picker_visible(page: Page) -> None:
+    """Assert the plate-subset multiselect is shown (Plate mode, order has plates)."""
+    expect(page.locator("marimo-multiselect")).to_have_count(1)
+
+
+def expect_plate_picker_hidden(page: Page) -> None:
+    """Assert the plate-subset multiselect is absent (e.g. Vial mode)."""
+    expect(page.locator("marimo-multiselect")).to_have_count(0)
+
+
+def expect_mixed_order_note_visible(page: Page) -> None:
+    """Assert the neutral mixed-composition info callout is shown."""
+    _assert_callout(page, "info", _MIXED_NOTE_TEXT)
+
+
+def expect_mixed_order_note_hidden(page: Page) -> None:
+    """Assert no mixed-composition info callout is shown (text-scoped to this note)."""
+    note = page.locator("marimo-callout-output[data-kind*='info']").filter(has_text=_MIXED_NOTE_TEXT)
+    expect(note).to_have_count(0)

--- a/tests/gui/features/plate_picker.feature
+++ b/tests/gui/features/plate_picker.feature
@@ -1,0 +1,46 @@
+Feature: The plate picker appears only where it has an effect
+  As a queue-app operator
+  I want the plate-subset picker shown only in Plate mode, plus a heads-up when
+  an order mixes plates and standalone samples
+  So that I am not misled by a control that silently does nothing in Vial mode.
+
+  # The picker only affects the Plate load path; in Vial mode get_samples ignores
+  # the selected plates (bfabric_utils.py), so it is hidden there. Gating lives in
+  # queue_app.py; the note is make_mixed_order_note in queue_app_shared.py. Fixtures:
+  # 37183 mixed (plates + off-plate), 37180 plate-only, 37182 vial-only.
+
+  Scenario: Plate mode shows the plate picker for an order with plates
+    Given the queue app is open as an employee
+    When I set "Tech Area" to "Metabolomics"
+    And I set "Instrument" to "EXPLORIS_3"
+    And I set "Sampler" to "Vanquish"
+    And I select order 37183
+    And I set "Queue Type" to "Plate"
+    Then the plate picker is shown
+
+  Scenario: Vial mode hides the plate picker
+    Given the queue app is open as an employee
+    When I set "Tech Area" to "Metabolomics"
+    And I set "Instrument" to "EXPLORIS_3"
+    And I set "Sampler" to "Vanquish"
+    And I select order 37183
+    And I set "Queue Type" to "Vial"
+    Then the plate picker is not shown
+
+  Scenario: A mixed order shows the composition note
+    Given the queue app is open as an employee
+    When I set "Tech Area" to "Metabolomics"
+    And I select order 37183
+    Then the mixed-order note is shown
+
+  Scenario: A plate-only order shows no composition note
+    Given the queue app is open as an employee
+    When I set "Tech Area" to "Proteomics"
+    And I select order 37180
+    Then the mixed-order note is not shown
+
+  Scenario: A vial-only order shows no composition note
+    Given the queue app is open as an employee
+    When I set "Tech Area" to "Proteomics"
+    And I select order 37182
+    Then the mixed-order note is not shown

--- a/tests/gui/test_plate_picker.py
+++ b/tests/gui/test_plate_picker.py
@@ -1,0 +1,53 @@
+"""GUI scenarios — the plate picker shows only in Plate mode; a neutral note
+flags mixed (plate+vial) orders.
+
+Gating lives in ``queue_app.py`` (the picker display cell requires
+``queue_type_field.value == "Plate"``); the note is ``make_mixed_order_note`` in
+``queue_app_shared.py``. Fixtures (see ``tests/gui/AGENTS.md``): 37183 is the mixed
+container (plate 50003 + off-plate samples, Metabolomics), 37180 is plate-only,
+37182 is vial-only.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from tests.gui import _helpers as H
+
+scenarios("features/plate_picker.feature")
+
+
+@given("the queue app is open as an employee")
+def _open_app(page: Page, queue_app_url: str) -> None:
+    H.open_app(page, queue_app_url)
+
+
+@when(parsers.parse('I set "{label}" to "{value}"'))
+def _set_selector(page: Page, label: str, value: str) -> None:
+    H.set_dropdown(page, label, value)
+
+
+@when(parsers.parse("I select order {container_id:d}"))
+def _select_order(page: Page, container_id: int) -> None:
+    H.select_order(page, container_id)
+
+
+@then("the plate picker is shown")
+def _picker_shown(page: Page) -> None:
+    H.expect_plate_picker_visible(page)
+
+
+@then("the plate picker is not shown")
+def _picker_hidden(page: Page) -> None:
+    H.expect_plate_picker_hidden(page)
+
+
+@then("the mixed-order note is shown")
+def _note_shown(page: Page) -> None:
+    H.expect_mixed_order_note_visible(page)
+
+
+@then("the mixed-order note is not shown")
+def _note_hidden(page: Page) -> None:
+    H.expect_mixed_order_note_hidden(page)

--- a/tests/test_queue_app_shared.py
+++ b/tests/test_queue_app_shared.py
@@ -37,6 +37,7 @@ from qg.apps.queue_app_shared import (
     filter_by_column,
     generate_queue,
     load_methods_table,
+    make_mixed_order_note,
     make_queue_type_field,
     params_json_filename,
     queue_output_filename,
@@ -700,3 +701,30 @@ class TestMakeQueueTypeField:
         assert "incompatible" in warning.text
         assert "MClass" in warning.text
         assert "the uploaded samples" in warning.text
+
+
+# ---------------------------------------------------------------------------
+# make_mixed_order_note
+# ---------------------------------------------------------------------------
+
+
+class TestMakeMixedOrderNote:
+    """Neutral heads-up shown only when an order holds both plates and vials.
+
+    Portal-only in effect: the local app derives the two flags as mutually
+    exclusive, so this helper returns ``None`` there. The wording is deliberately
+    factual (composition, not consequences) — queue-type guidance is left to a
+    later change.
+    """
+
+    def test_mixed_returns_callout(self):
+        note = make_mixed_order_note(has_plates=True, has_vials=True)
+        assert note is not None
+        assert "plate-resident and standalone" in note.text
+
+    @pytest.mark.parametrize(
+        ("has_plates", "has_vials"),
+        [(True, False), (False, True), (False, False)],
+    )
+    def test_non_mixed_returns_none(self, has_plates, has_vials):
+        assert make_mixed_order_note(has_plates=has_plates, has_vials=has_vials) is None

--- a/uv.lock
+++ b/uv.lock
@@ -1900,7 +1900,7 @@ wheels = [
 
 [[package]]
 name = "qg"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "altair" },


### PR DESCRIPTION
The plate-subset picker only affects Plate-mode sample loading — in Vial mode
the loader ignores the selected plates — yet it was displayed whenever the
order contained plates, which made it look like a working subset control when
it did nothing.

Key changes:
- Show the plate picker only when Queue Type is Plate. Per-sample subsetting via
  the samples table is unchanged.
- Add a neutral note when an order contains both plate-resident and standalone
  (vial) samples (informational only).

Testing: new unit test for the note helper plus a GUI scenario covering picker
visibility per mode and the note across plate-only / vial-only / mixed orders;
full suite green.

🤖 Prepared with assistance from Claude Opus 4.8 via Claude Code.
