### PR TITLE
fix: align workunit upload with the bfabricPy feeder API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Type-checked `bfabric_utils.py` with pyright, so B-Fabric API drift fails at pre-commit instead of at upload time.
+
+### Fixed
+- Fixed portal workunit upload, which failed with a `TypeError` against the current bfabricPy feeder API.
+
 ## [0.11.0] - 2026-08-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qg"
-version = "0.11.0"
+version = "0.11.1"
 description = "Queue generation system for mass spectrometry instruments. Generates sample queues with QC injections for XCalibur, Chronos, and Hystar, with B-Fabric LIMS integration for sample loading and workunit upload."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -149,7 +149,6 @@ pythonVersion = "3.14"
 include = ["src/qg"]
 exclude = [
     "src/qg/apps",         # marimo apps have looser typing
-    "src/qg/bfabric_utils.py",  # external API types
 ]
 typeCheckingMode = "standard"
 reportUndefinedVariable = "error"

--- a/src/qg/apps/integrations/bfabric_workunit.py
+++ b/src/qg/apps/integrations/bfabric_workunit.py
@@ -1,6 +1,6 @@
 """B-Fabric workunit sink for the portal queue app.
 
-Builds the ``CreateWorkunitParams`` payload (queue file + params.json resources)
+Builds the ``CreateWorkunitRequest`` payload (queue file + params.json resources)
 the portal uploads via the feeder. Importing this module requires the
 ``qg[bfabric]`` extra.
 """
@@ -11,7 +11,7 @@ import base64
 from typing import TYPE_CHECKING
 
 import yaml
-from bfabric_rest_proxy.feeder_operations.create_workunit import CreateWorkunitParams
+from bfabric_rest_proxy.feeder_operations.create_workunit import CreateWorkunitRequest
 
 if TYPE_CHECKING:
     from qg.params_models import QueueInput
@@ -25,7 +25,7 @@ def gather_workunit_parameters(
     target_container_id: int,
     queue_output_filename: str,
     queue_output_str: str,
-) -> CreateWorkunitParams:
+) -> CreateWorkunitRequest:
     """Assemble the workunit payload for a generated queue.
 
     Parameter values are stringified (lists/dicts as flow-style YAML) to match the
@@ -39,7 +39,7 @@ def gather_workunit_parameters(
         else:
             parameters[key] = str(parameters[key])
 
-    return CreateWorkunitParams(
+    return CreateWorkunitRequest(
         container_id=target_container_id,
         application_id=application_id,
         workunit_name=queue_output_filename.split(".")[0],
@@ -51,4 +51,5 @@ def gather_workunit_parameters(
         links={},
         input_resource_ids=[],
         description=f"Queue configuration generated with qg version {app_version}.",
+        created_using=f"qg {app_version}",
     )

--- a/src/qg/apps/queue_app.py
+++ b/src/qg/apps/queue_app.py
@@ -903,7 +903,7 @@ def _(
     queue_output_str,
     target_container_id_field,
 ):
-    def gather_workunit_parameters() -> bfabric_workunit.CreateWorkunitParams:
+    def gather_workunit_parameters() -> bfabric_workunit.CreateWorkunitRequest:
         # Upload is only reachable once a queue is generated, which implies a
         # selected order (hence a non-None container field). See the upload cell.
         assert queue_input is not None

--- a/src/qg/bfabric_utils.py
+++ b/src/qg/bfabric_utils.py
@@ -5,12 +5,12 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
 
-from bfabric import Bfabric, BfabricClientConfig
+from bfabric import BaseUrl, Bfabric, BfabricClientConfig
 from bfabric.config.config_data import ConfigData
 from bfabric_asgi_auth.session_data import SessionData
 from bfabric_asgi_auth.user import BfabricUser
 from bfabric_rest_proxy.feeder_operations.create_workunit import (
-    CreateWorkunitParams,
+    CreateWorkunitRequest,
     create_workunit,
 )
 from bfabric_rest_proxy.feeder_operations.is_employee import is_employee as _check_is_employee
@@ -40,11 +40,11 @@ class BfabricFeederUploader:
         self._user_client = user_client
         self._feeder_client = feeder_client
 
-    def upload(self, params: CreateWorkunitParams) -> str:
+    def upload(self, request: CreateWorkunitRequest) -> str:
         result = create_workunit(
             user_client=self._user_client,
             feeder_client=self._feeder_client,
-            params=params,
+            request=request,
         )
         return f"Created [Workunit {result.id}]({result.uri})"
 
@@ -52,10 +52,10 @@ class BfabricFeederUploader:
 class MockFeederUploader:
     """Mock uploader for local testing."""
 
-    def upload(self, params: CreateWorkunitParams) -> str:
+    def upload(self, request: CreateWorkunitRequest) -> str:
         return (
-            f"**[Mock]** Would create workunit in container {params.container_id} "
-            f"with {len(params.resources)} resources."
+            f"**[Mock]** Would create workunit in container {request.container_id} "
+            f"with {len(request.resources)} resources."
         )
 
 
@@ -93,7 +93,7 @@ def make_feeder_client(app_config, instance_url: str) -> Bfabric:
         raise SessionError(
             f"Feeder credentials not configured for instance {instance_url!r}; cannot determine employee status."
         )
-    return Bfabric(ConfigData(auth=creds, client=BfabricClientConfig(base_url=instance_url)))
+    return Bfabric(ConfigData(auth=creds, client=BfabricClientConfig(base_url=BaseUrl(instance_url))))
 
 
 @dataclass(frozen=True)

--- a/tests/test_bfabric_utils.py
+++ b/tests/test_bfabric_utils.py
@@ -1,4 +1,4 @@
-"""Tests for B-Fabric helpers — instance slug, per-instance cache layout."""
+"""Tests for B-Fabric helpers — instance slug, per-instance cache layout, feeder upload."""
 
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -8,10 +8,23 @@ import pytest
 
 pytest.importorskip("bfabric")  # core install (no qg[bfabric]) skips this module
 
-from qg.bfabric_utils import instance_slug  # noqa: E402
+from bfabric_rest_proxy.feeder_operations import create_workunit as proxy_create_workunit  # noqa: E402
+
+from qg.apps.integrations import bfabric_workunit  # noqa: E402
+from qg.bfabric_utils import BfabricFeederUploader, instance_slug  # noqa: E402
 from qg.cli.find_projects import ContainerCache, get_cache_dir  # noqa: E402
+from qg.config_models.loader import qg_configuration  # noqa: E402
+
+from .helpers import make_queue_input  # noqa: E402
 
 pytestmark = pytest.mark.bfabric
+
+_CONFIG_DIR = Path(__file__).resolve().parents[1] / "qg_configs"
+
+
+@pytest.fixture(scope="session")
+def config():
+    return qg_configuration(_CONFIG_DIR)
 
 
 class _FakeClient:
@@ -248,3 +261,63 @@ def test_read_containers_honors_active_only_suffix(monkeypatch, tmp_path: Path) 
     # active-only reader sees no file (different suffix) -> empty; all-projects reader sees the row.
     assert ContainerCache(client).read_containers().is_empty()
     assert ContainerCache(client, active_only=False).read_containers()["Container ID"].to_list() == [7]
+
+
+# ---------------------------------------------------------------------------
+# BfabricFeederUploader — call shape against the bfabricPy feeder API
+# ---------------------------------------------------------------------------
+
+
+def test_feeder_uploader_calls_proxy_with_request(monkeypatch) -> None:
+    """Drive the real proxy wrapper, stubbing only its innermost core call.
+
+    Pins the upload call shape so an upstream rename fails here instead of in the app:
+    a wrong keyword raises TypeError, and a bare `CreateWorkunitParams` (no
+    `created_using`) raises AttributeError inside the wrapper. `_create_workunit` is
+    bound in the proxy module at import time, so that is the only patchable seam.
+    """
+    captured = {}
+
+    def _fake_core(client, params, audit_attributes=None):
+        captured["client"] = client
+        captured["params"] = params
+        captured["audit_attributes"] = audit_attributes
+        return MagicMock(id=4242, uri="https://fgcz-bfabric.uzh.ch/bfabric/workunit/show.html?id=4242")
+
+    monkeypatch.setattr(proxy_create_workunit, "_create_workunit", _fake_core)
+
+    user_client = MagicMock()
+    user_client.auth.login = "cpanse"
+    user_client.read.return_value = [{"id": 1234}]  # container authorization passes
+    feeder_client = MagicMock()
+
+    request = proxy_create_workunit.CreateWorkunitRequest(
+        container_id=1234,
+        application_id=401,
+        workunit_name="queue_20260827",
+        parameters={"instrument": "ASTRAL_1"},
+        created_using="qg 0.11.1",
+    )
+    message = BfabricFeederUploader(user_client, feeder_client).upload(request)
+
+    assert message == "Created [Workunit 4242](https://fgcz-bfabric.uzh.ch/bfabric/workunit/show.html?id=4242)"
+    assert captured["client"] is feeder_client
+    assert captured["audit_attributes"] == {"Created For": "cpanse", "Created Using": "qg 0.11.1"}
+
+
+def test_gather_workunit_parameters_builds_request(config) -> None:
+    """The portal payload must be a request (params + `created_using`), not bare params."""
+    request = bfabric_workunit.gather_workunit_parameters(
+        make_queue_input(config=config, num_samples=3),
+        app_version="9.9.9",
+        application_id=401,
+        target_container_id=12345,
+        queue_output_filename="queue_20260827.csv",
+        queue_output_str="a,b\n1,2\n",
+    )
+
+    assert isinstance(request, proxy_create_workunit.CreateWorkunitRequest)
+    assert request.created_using == "qg 9.9.9"
+    assert request.container_id == 12345
+    assert request.workunit_name == "queue_20260827"
+    assert set(request.resources) == {"queue_20260827.csv", "parameters.json"}

--- a/uv.lock
+++ b/uv.lock
@@ -2105,7 +2105,7 @@ wheels = [
 
 [[package]]
 name = "qg"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
Adapt to change in bfabricPy.

- `upload` passes `request=`; the payload builder returns a `CreateWorkunitRequest` with `created_using="qg <version>"`.
- `bfabric_utils.py` is back under pyright, which flags this exact break (`No parameter named "params"`) and was the only thing that would have caught it.
- Regression test added.

🤖 Prepared with assistance from Claude Opus 5 via Claude Code.